### PR TITLE
Support using next-fetch-har on Page components.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,17 +90,17 @@ export function ServerHttpArchive({ har }) {
 }
 
 export function withFetchHar(
-  App,
+  AppOrPage,
   {
     fetch: baseFetch = global.fetch,
     enabled = process.env.NODE_ENV !== "production",
     ...options
   } = {}
 ) {
-  const name = App.displayName || App.name || "App";
+  const name = AppOrPage.displayName || AppOrPage.name || "AppOrPage";
 
   class WithFetchHar extends React.Component {
-    static displayName = `withFetchHar(${App})`;
+    static displayName = `withFetchHar(${AppOrPage})`;
 
     static async getInitialProps(appContext) {
       const isApp = !!appContext.Component;
@@ -116,7 +116,7 @@ export function withFetchHar(
         ctx.fetch = withHar(fetch, { ...options, har });
       }
 
-      const initialProps = await App.getInitialProps(appContext);
+      const initialProps = await AppOrPage.getInitialProps(appContext);
 
       return { ...initialProps, har };
     }
@@ -125,7 +125,7 @@ export function withFetchHar(
       const { har, ...props } = this.props;
       return (
         <>
-          <App {...props} />
+          <AppOrPage {...props} />
           <ServerHttpArchive har={har} />
         </>
       );

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,8 @@ export function withFetchHar(
     static displayName = `withFetchHar(${App})`;
 
     static async getInitialProps(appContext) {
-      const { ctx } = appContext;
+      const isApp = !!appContext.Component;
+      const ctx = isApp ? appContext.ctx : appContext;
       let har = null;
       const skip = typeof enabled === "function" ? !enabled(ctx) : !enabled;
 


### PR DESCRIPTION
Smol PR here. This just adds support for using `next-fetch-har` with Page components rather than having to wrap `_app.js`. We do this by checking to see if the `appContext` object has `Component` on it (style of `_app.js`) or not (style of page components) and then attach `fetch` to the proper `ctx` object for the component we're wrapping!